### PR TITLE
:art: chore: `MYKN` as the prefix for public `.env` variables

### DIFF
--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -1,14 +1,13 @@
 import { getCookie } from "@maykin-ui/client-common/cookie";
 
 /** The base origin for all API requests. */
-export const API_URL = import.meta.env.VITE_API_URL || window.location.origin;
+export const API_URL = import.meta.env.MYKN_API_URL || window.location.origin;
 
 /** The base path for all API requests. */
-export const API_PATH = import.meta.env.VITE_API_PATH || "/api/v1";
+export const API_PATH = import.meta.env.MYKN_API_PATH || "/api/v1";
 
 /** The base url for all API requests. */
 export const API_BASE_URL = `${API_URL}${API_PATH}`;
-
 /**
  * Makes an actual fetch request to the API, should be used by all other API implementations.
  * @param method - method to use for the request

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
-  readonly VITE_API_PATH: string;
+  readonly MYKN_API_URL: string;
+  readonly MYKN_API_PATH: string;
 }
 
 interface ImportMeta {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   build: {
     assetsDir: "static/assets",
   },
+  envPrefix: "MYKN_",
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "src"),


### PR DESCRIPTION
Instead of .env variables being `VITE_BAR` they can now be `MYKN_BAR`