### PR TITLE
Turn on isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,2 @@
 dfee655ead59e8b541195d3fb48492fdbd96f140  # code format
+7c5a728d98b2deaf610155b3d4e52a4aaf1afd4f  # isort sorting

--- a/backend/src/openbeheer/api/authentication/authentication.py
+++ b/backend/src/openbeheer/api/authentication/authentication.py
@@ -1,5 +1,5 @@
-from rest_framework import authentication
 from drf_spectacular.authentication import SessionScheme
+from rest_framework import authentication
 
 
 class AnonCSRFSessionAuthentication(authentication.SessionAuthentication):

--- a/backend/src/openbeheer/catalogi/api/views.py
+++ b/backend/src/openbeheer/catalogi/api/views.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy as _
+
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from msgspec.json import decode
 from rest_framework.request import Request

--- a/backend/src/openbeheer/catalogi/tests/test_views.py
+++ b/backend/src/openbeheer/catalogi/tests/test_views.py
@@ -1,9 +1,9 @@
-from rest_framework.test import APITestCase
-from rest_framework.reverse import reverse
+from maykin_common.vcr import VCRMixin
 from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
-from maykin_common.vcr import VCRMixin
 
 from openbeheer.accounts.tests.factories import UserFactory
 

--- a/backend/src/openbeheer/catalogi/urls.py
+++ b/backend/src/openbeheer/catalogi/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .api.views import CatalogChoicesView
 
+from .api.views import CatalogChoicesView
 
 app_name = "catalogi"
 

--- a/backend/src/openbeheer/health_checks/api/views.py
+++ b/backend/src/openbeheer/health_checks/api/views.py
@@ -1,9 +1,9 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from drf_spectacular.utils import extend_schema, extend_schema_view
-from ..types import HealthCheckSerialisedResult
 
+from ..types import HealthCheckSerialisedResult
 from ..utils import run_health_checks
 
 

--- a/backend/src/openbeheer/health_checks/checks.py
+++ b/backend/src/openbeheer/health_checks/checks.py
@@ -1,9 +1,9 @@
 import traceback
 from abc import ABC, abstractmethod
 from typing import Union
-from django.utils.functional import Promise
 
 from django.conf import settings
+from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
 
 from requests.exceptions import ConnectionError, HTTPError

--- a/backend/src/openbeheer/health_checks/tests/test_management.py
+++ b/backend/src/openbeheer/health_checks/tests/test_management.py
@@ -2,10 +2,9 @@ from io import StringIO
 
 from django.core.management import call_command
 
+from maykin_common.vcr import VCRTestCase
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
-
-from maykin_common.vcr import VCRTestCase
 
 
 class HealthCheckManagementTest(VCRTestCase):

--- a/backend/src/openbeheer/health_checks/tests/test_service_checks.py
+++ b/backend/src/openbeheer/health_checks/tests/test_service_checks.py
@@ -1,9 +1,8 @@
 from django.test import TestCase, tag
 from django.utils.translation import gettext as _
 
-from requests.exceptions import ConnectTimeout
-
 from maykin_common.vcr import VCRMixin
+from requests.exceptions import ConnectTimeout
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 

--- a/backend/src/openbeheer/informatieobjecttypen/api/views.py
+++ b/backend/src/openbeheer/informatieobjecttypen/api/views.py
@@ -1,8 +1,13 @@
 from typing import Mapping
+
+from ape_pie import APIClient
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework.request import Request
+
 from openbeheer.api.views import ListView
 from openbeheer.informatieobjecttypen.types import (
-    InformatieObjectTypeSummary,
     InformatieObjectTypenGetParametersQuery,
+    InformatieObjectTypeSummary,
 )
 from openbeheer.types._open_beheer import (
     ExternalServiceError,
@@ -12,9 +17,6 @@ from openbeheer.types._open_beheer import (
 )
 from openbeheer.types._zgw import ZGWError
 from openbeheer.types.ztc import VertrouwelijkheidaanduidingEnum
-from ape_pie import APIClient
-from rest_framework.request import Request
-from drf_spectacular.utils import extend_schema, extend_schema_view
 
 
 @extend_schema_view(

--- a/backend/src/openbeheer/informatieobjecttypen/tests/test_views.py
+++ b/backend/src/openbeheer/informatieobjecttypen/tests/test_views.py
@@ -1,13 +1,12 @@
-from rest_framework.test import APITestCase
+from furl import furl
+from maykin_common.vcr import VCRMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
-from maykin_common.vcr import VCRMixin
 
 from openbeheer.accounts.tests.factories import UserFactory
-from furl import furl
-
 from openbeheer.utils.open_zaak_helper.data_creation import OpenZaakDataCreationHelper
 
 

--- a/backend/src/openbeheer/informatieobjecttypen/types.py
+++ b/backend/src/openbeheer/informatieobjecttypen/types.py
@@ -1,12 +1,10 @@
-from openbeheer.types._open_beheer import OBPagedQueryParams, VersionedResourceSummary
-from openbeheer.types.ztc import Status
-
+import datetime
+from typing import Annotated
 
 from msgspec import UNSET, Meta, UnsetType
 
-
-import datetime
-from typing import Annotated
+from openbeheer.types._open_beheer import OBPagedQueryParams, VersionedResourceSummary
+from openbeheer.types.ztc import Status
 
 
 class InformatieObjectTypenGetParametersQuery(

--- a/backend/src/openbeheer/services/api/views.py
+++ b/backend/src/openbeheer/services/api/views.py
@@ -1,19 +1,14 @@
 from django.utils.translation import gettext_lazy as _
 
-from drf_spectacular.utils import extend_schema
-
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
 
-from rest_framework.request import Request
-from rest_framework.permissions import IsAuthenticated
-
 from openbeheer.api.views import MsgspecAPIView
-
 from openbeheer.types import OBOption
-from rest_framework.response import Response
-
-from drf_spectacular.utils import extend_schema_view
 
 
 @extend_schema_view(

--- a/backend/src/openbeheer/services/tests/test_views.py
+++ b/backend/src/openbeheer/services/tests/test_views.py
@@ -1,6 +1,6 @@
-from rest_framework.test import APITestCase
-from rest_framework.reverse import reverse
 from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 

--- a/backend/src/openbeheer/services/urls.py
+++ b/backend/src/openbeheer/services/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from .api.views import ServiceChoicesView
 
-
 app_name = "services"
 
 urlpatterns = [

--- a/backend/src/openbeheer/tests/test_clients.py
+++ b/backend/src/openbeheer/tests/test_clients.py
@@ -1,7 +1,7 @@
-from ape_pie import APIClient
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
+from ape_pie import APIClient
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 

--- a/backend/src/openbeheer/types/_drf_spectacular.py
+++ b/backend/src/openbeheer/types/_drf_spectacular.py
@@ -1,5 +1,5 @@
-from msgspec import field, Struct, to_builtins
 from drf_spectacular.extensions import _SchemaType
+from msgspec import Struct, field, to_builtins
 
 
 class QueryParamSchema(Struct):

--- a/backend/src/openbeheer/types/_open_beheer.py
+++ b/backend/src/openbeheer/types/_open_beheer.py
@@ -1,11 +1,11 @@
-import enum
 import datetime
+import enum
 from functools import singledispatch
 from types import NoneType, UnionType
 from typing import Self, Sequence
 
-from ape_pie import APIClient
 import msgspec
+from ape_pie import APIClient
 from msgspec import UNSET, Struct, UnsetType
 
 

--- a/backend/src/openbeheer/types/_zgw.py
+++ b/backend/src/openbeheer/types/_zgw.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+
 from msgspec import UNSET, Meta, Struct, UnsetType
 
 

--- a/backend/src/openbeheer/types/ztc.py
+++ b/backend/src/openbeheer/types/ztc.py
@@ -4,8 +4,10 @@
 #   version:   0.30.1
 
 from __future__ import annotations
+
 from enum import Enum
 from typing import Annotated, List
+
 from msgspec import Meta, Struct, field
 
 

--- a/backend/src/openbeheer/utils/decorators.py
+++ b/backend/src/openbeheer/utils/decorators.py
@@ -1,7 +1,8 @@
 from functools import wraps
 from typing import Callable, ParamSpec
-from rest_framework.response import Response
+
 from requests.exceptions import ConnectionError, ReadTimeout
+from rest_framework.response import Response
 
 from openbeheer.types import ExternalServiceError
 

--- a/backend/src/openbeheer/utils/open_zaak_helper/data_creation.py
+++ b/backend/src/openbeheer/utils/open_zaak_helper/data_creation.py
@@ -1,6 +1,10 @@
+import string
 from dataclasses import dataclass
+from random import choice
 from typing import Type
+
 from msgspec.json import decode
+
 from openbeheer.clients import ztc_client
 from openbeheer.types.ztc import (
     Catalogus,
@@ -10,8 +14,6 @@ from openbeheer.types.ztc import (
     ZaakType,
     ZaakTypeInformatieObjectType,
 )
-from random import choice
-import string
 
 
 @dataclass

--- a/backend/src/openbeheer/utils/validators.py
+++ b/backend/src/openbeheer/utils/validators.py
@@ -1,4 +1,5 @@
 import re
+
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils.encoding import force_str

--- a/backend/src/openbeheer/zaaktype/api/views.py
+++ b/backend/src/openbeheer/zaaktype/api/views.py
@@ -8,6 +8,10 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from furl import furl
 from msgspec import UNSET, Meta, UnsetType
 from msgspec.json import decode
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
 from openbeheer.api.views import (
     DetailView,
     ListView,
@@ -45,9 +49,6 @@ from openbeheer.types.ztc import (
 )
 from openbeheer.utils.decorators import handle_service_errors
 from openbeheer.zaaktype.constants import ZAAKTYPE_FIELDSETS
-from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 if TYPE_CHECKING:
     from ape_pie import APIClient

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
@@ -1,9 +1,10 @@
 from django.test import tag
+
 from furl import furl
+from maykin_common.vcr import VCRMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from maykin_common.vcr import VCRMixin
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
@@ -1,7 +1,7 @@
+from maykin_common.vcr import VCRMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from maykin_common.vcr import VCRMixin
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,6 +33,8 @@ select = [
     "FURB",
     # pep8-naming
     "N",
+    # isort
+    "I",
 ]
 ignore = [
     "E501", # line too long


### PR DESCRIPTION
isort rules were configured, but not enforced

It's nothing exciting. If you have merge conflicts, just pick all your own changes and only run `ruff check --fix`. that will put your changes in the same, expected order.