### PR TITLE
Fix OAS response schema for list views

### DIFF
--- a/backend/src/openbeheer/types/__init__.py
+++ b/backend/src/openbeheer/types/__init__.py
@@ -14,6 +14,7 @@ from ._open_beheer import (
     VersionSummary,
     as_ob_fieldtype,
     as_ob_option,
+    options,
 )
 from ._zgw import ZGWError, ZGWResponse
 
@@ -33,4 +34,5 @@ __all__ = [
     "ZGWResponse",
     "as_ob_fieldtype",
     "as_ob_option",
+    "options",
 ]

--- a/backend/src/openbeheer/zaaktype/api/views.py
+++ b/backend/src/openbeheer/zaaktype/api/views.py
@@ -26,8 +26,6 @@ from openbeheer.types import (
     ZGWError,
 )
 from openbeheer.types._open_beheer import (
-    ExternalServiceError,
-    OBList,
     VersionedResourceSummary,
 )
 from openbeheer.types.ztc import (
@@ -88,13 +86,7 @@ class ZaakTypeSummary(VersionedResourceSummary, kw_only=True, rename="camel"):
         summary="Get zaaktypen",
         parameters=[],
         filters=True,
-        description="Retrive zaaktypen from Open Zaak.",
-        responses={
-            "200": OBList[ZaakTypeSummary],
-            "400": ZGWError,
-            "502": ExternalServiceError,
-            "504": ExternalServiceError,
-        },
+        description="Retrieve zaaktypen from Open Zaak.",
     ),
     post=extend_schema(
         tags=["Zaaktypen"],


### PR DESCRIPTION
The ZaakTypeListView 200 response type was set incorrectly, resulting in an incorrect spec.

Note: Maybe the naming of OBList and DetailResponse should be brought more in line with each other.
 - `OverviewResponse[T]` in the Figma they're called "Overzicht"
 - `SummaryResponse[T]` It currently contains ZaakTypeSummary