### PR TITLE
:bug: [#169] fix: define list ZT field order, undefine options

### DIFF
--- a/backend/src/openbeheer/informatieobjecttypen/api/views.py
+++ b/backend/src/openbeheer/informatieobjecttypen/api/views.py
@@ -63,6 +63,7 @@ class InformatieObjectTypeListView(
         self,
         params: InformatieObjectTypenGetParametersQuery,
         option_overrides: Mapping[str, list[OBOption]] = {},
+        **_,
     ) -> list[OBField]:
         return super().parse_ob_fields(
             params,

--- a/backend/src/openbeheer/types/_open_beheer.py
+++ b/backend/src/openbeheer/types/_open_beheer.py
@@ -124,7 +124,7 @@ def options(t: type | UnionType) -> list[OBOption]:
             return []
 
 
-class OBField[T](Struct, rename="camel"):
+class OBField[T](Struct, rename="camel", omit_defaults=True):
     """Used by frontend to draw list views"""
 
     name: str
@@ -135,11 +135,11 @@ class OBField[T](Struct, rename="camel"):
     filter_value: T | UnsetType = msgspec.UNSET
     'The currently "selected" value'
 
-    filter_lookup: str | UnsetType = ""
+    filter_lookup: str | UnsetType = msgspec.UNSET
     """The "lookup" (query parameter) to use for this field while filtering (e.g.
     "omschrijving__icontains")."""
 
-    options: list[OBOption] | UnsetType = []
+    options: list[OBOption] | UnsetType = msgspec.UNSET
     "fields that are not query parameter MAY need options too"
 
     def __post_init__(self):

--- a/backend/src/openbeheer/zaaktype/api/views.py
+++ b/backend/src/openbeheer/zaaktype/api/views.py
@@ -160,18 +160,32 @@ class ZaakTypeListView(
     query_type = ZaaktypenGetParametersQuery
     endpoint_path = "zaaktypen"
 
+    @override
     def parse_ob_fields(
         self,
         params: ZaaktypenGetParametersQuery,
         option_overrides: Mapping[str, list[OBOption]] = {},
+        **_,
     ) -> list[OBField]:
+        order = [
+            "url",
+            "identificatie",
+            "omschrijving",
+            "vertrouwelijkheidaanduiding",
+            "versiedatum",
+            "actief",
+            "eindeGeldigheid",
+            "concept",
+        ]
         return super().parse_ob_fields(
             params,
-            {
+            dict(option_overrides)
+            | {
                 "vertrouwelijkheidaanduiding": OBOption.from_enum(
                     VertrouwelijkheidaanduidingEnum
                 )
             },
+            sort_key=lambda f: order.index(f.name),
         )
 
     @override

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
@@ -44,27 +44,33 @@ class ZaakTypeListViewTest(VCRMixin, APITestCase):
 
         self.assertGreater(data["pagination"]["count"], 0)
 
-        field_names = {f["name"] for f in data["fields"]}
+        field_names = [f["name"] for f in data["fields"]]
 
-        # has specced fields
-        self.assertSetEqual(
+        # has specced fields in correct order
+        self.assertListEqual(
             field_names,
-            {
+            [
                 "url",
-                "omschrijving",
                 "identificatie",
-                "eindeGeldigheid",
-                "versiedatum",
+                "omschrijving",
                 "vertrouwelijkheidaanduiding",
+                "versiedatum",
                 "actief",
+                "eindeGeldigheid",
                 "concept",
-            },
+            ],
         )
 
         # all rows have at least all fields
         for row in data["results"]:
-            keys_in_fields = set(row.keys()) & field_names
-            self.assertSetEqual(keys_in_fields, field_names)
+            keys_in_fields = set(row.keys()) & set(field_names)
+            self.assertSetEqual(keys_in_fields, set(field_names))
+
+        identificatie = data["fields"][1]
+        assert identificatie["name"] == "identificatie"
+        # options should be undefined if there are no options
+        # [] renders to an empty select
+        self.assertNotIn("options", identificatie.keys())
 
         versiedatum = next(f for f in data["fields"] if f["name"] == "versiedatum")
         self.assertEqual(versiedatum["type"], "date")


### PR DESCRIPTION
- Order of the `OBList.fields` fields is used by front-end for rendering.
- `OBField.options` should be undefined if not applicable
  > Maar options moet undefined zijn indien geen optins, dit betekent een lege seleect
  
 Fixes #169 