### PR TITLE
:construction: [#192] feat: Set the correct columns for Resultaattype…

### DIFF
--- a/frontend/src/pages/zaaktype/tabs/resultaattypen.tsx
+++ b/frontend/src/pages/zaaktype/tabs/resultaattypen.tsx
@@ -6,11 +6,13 @@ export const TABS_CONFIG_RESULTAATTYPEN: TabConfig<TargetType> = {
   sections: [
     {
       expandFields: [
-        "resultaattypenOmschrijving",
-        "resultaattypeomschrijving",
-        "selectielijstklasse",
-        "url",
-      ], // TODO: Missing "uuid"
+        "_expand.resultaattypen.omschrijving",
+        // See https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/#ztc-002
+        // omschrijvingGeneriek == label of resultaattypeomschrijving
+        "_expand.resultaattypen.resultaattypeomschrijving",
+        "_expand.resultaattypen.selectielijstklasse",
+        "_expand.resultaattypen.uuid",
+      ],
       label: "Resultaattypen",
       key: "resultaattypen",
     },


### PR DESCRIPTION
…n tab

According to the design:
 - Omschrijving
 - Omschrijving Generiek
 - Selectielijstklasse
 - UUID

See https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/#ztc-002 Omschrijving Generiek is actually the omschrijving of the resource at the URL in the resultaattypeomschrijving, which the BFF puts in the label of the option.