### PR TITLE
:bug: fix: Fix editable on list view and uuid fields

### DIFF
--- a/backend/src/openbeheer/api/views.py
+++ b/backend/src/openbeheer/api/views.py
@@ -425,16 +425,24 @@ class ListView[P: OBPagedQueryParams, T: Struct, S: Struct](MsgspecAPIView):
         option_overrides: Mapping[str, list[OBOption]] = {},
         *,
         sort_key: Callable[[OBField], Comparable] = lambda f: f.name,
+        base_editable: Callable[[str], bool] = bool,
     ) -> list[OBField]:
         """Create OBFields for the attributes on `self.data_type`
 
-        `params`: Incoming query params, so we can echo values back
-        `option_overrides`: Mapping[field name, list[OBOption[field type]]]
-                            Options are inferred from the type annotation of
-                            `self.data_type`, but that may be set more general.
+        :param params: Incoming query params, so we can echo values back
+        :param option_overrides: Mapping[field name, list[OBOption[field type]]]
+                                 Options are inferred from the type annotation of
+                                 `self.data_type`, but that may be set more general.
+        :param base_editable: A function that takes a field name and returns wheter
+                              that field should be editable.
         """
         return sorted(
-            ob_fields_of_type(self.return_data_type, params, option_overrides),
+            ob_fields_of_type(
+                self.return_data_type,
+                params,
+                option_overrides,
+                base_editable=base_editable,
+            ),
             key=sort_key,
         )
 

--- a/backend/src/openbeheer/zaaktype/api/views.py
+++ b/backend/src/openbeheer/zaaktype/api/views.py
@@ -168,6 +168,7 @@ class ZaakTypeListView(
                 )
             },
             sort_key=lambda f: order.index(f.name),
+            base_editable=lambda _: False,  # no editable fields
         )
 
     @override

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
@@ -389,6 +389,8 @@ class ZaakTypeDetailViewTest(VCRAPITestCase):
             }
             # has some editable fields
             assert len(editable_fields)
+            # but uuid's are added by us
+            assert "_expand.resultaattypen.uuid" not in editable_fields
             # but they should come from the ZTC service
             assert {
                 name

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_list_endpoint.py
@@ -74,6 +74,9 @@ class ZaakTypeListViewTest(VCRAPITestCase):
         # [] renders to an empty select
         self.assertNotIn("options", identificatie.keys())
 
+        # no editable fields
+        assert {repr(f) for f in data["fields"] if f.get("editable")} == set()
+
         versiedatum = next(f for f in data["fields"] if f["name"] == "versiedatum")
         self.assertEqual(versiedatum["type"], "date")
 


### PR DESCRIPTION
 - Zaaktype list view should have no editable fields at all.
 - UUID fields are identifiers and are not editable