### PR TITLE
:sparkles: [#268] feat: Add OB field type duration

### DIFF
--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
@@ -404,6 +404,26 @@ class ZaakTypeDetailViewTest(VCRAPITestCase):
             # but statustypen has a tab
             assert "statustypen" not in editable_fields
 
+            assert (
+                fields_by_name["_expand.eigenschappen.beginGeldigheid"]["type"]
+                == "date"
+            )
+            assert "_expand.eigenschappen.naam" in editable_fields
+            assert "_expand.eigenschappen.beginGeldigheid" in editable_fields
+            assert (
+                fields_by_name["_expand.eigenschappen.eindeGeldigheid"]["type"]
+                == "date"
+            )
+            assert "_expand.eigenschappen.eindeGeldigheid" in editable_fields
+
+            assert fields_by_name["_expand.eigenschappen.statustype"]["options"] == [
+                {"label": statustype.omschrijving, "value": statustype.url}
+            ]
+
+        assert (
+            fields_by_name["_expand.besluittypen.reactietermijn"]["type"] == "duration"
+        )
+
         with self.subTest("All fields in the fieldsets should exist"):
             fields_in_fieldsets = set(
                 sum((fieldset["fields"] for _, fieldset in data["fieldsets"]), [])


### PR DESCRIPTION
Termijnen in ISO 8601 Durations are not marked as formatted as such, in the OAS spec from OZ. So we hard-code it in order for the frontend to render the coolest Duration widget known to NPM.