### PR TITLE
 Change label and order of ProcesType…

### DIFF
--- a/backend/src/openbeheer/types/_open_beheer.py
+++ b/backend/src/openbeheer/types/_open_beheer.py
@@ -207,7 +207,7 @@ def fetch_procestype_options():
 
     procestypen = decode(response.content, type=list[LAXProcesType])
     return [
-        as_ob_option(p) for p in sorted(procestypen, key=lambda v: (-v.jaar, v.naam))
+        as_ob_option(p) for p in sorted(procestypen, key=lambda v: (-v.jaar, v.nummer))
     ]
 
 
@@ -765,7 +765,7 @@ class ExpandableZaakType(ZaakTypeWithUUID, Struct):
 
 @as_ob_option.register
 def _lax_procestype_as_option(arg: ProcesType) -> OBOption[str | None]:
-    return OBOption(label=f"{arg.naam} - {arg.jaar}", value=arg.url)
+    return OBOption(label=f"{arg.jaar} - {arg.nummer} - {arg.naam}", value=arg.url)
 
 
 # Types from read only (or not implemented CUD) API's

--- a/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
+++ b/backend/src/openbeheer/zaaktype/tests/test_zaaktype_detail.py
@@ -767,12 +767,8 @@ class ZaakTypeDetailViewTest(VCRAPITestCase):
             # Value should be a URL
             self.assertIn("https://", value)
 
-            # Within same year, should be sorted alphabetically
-            if year == previous_year:
-                self.assertGreater(label, previous_label)
             # Years should be descending.
-            else:
-                self.assertLess(year, previous_year)
+            self.assertLessEqual(year, previous_year)
 
             previous = option
 


### PR DESCRIPTION
… options

IMHO, having the "nummer" first gives better UX, because the user knows the number they need by heart, and the most recent jaar is most often needed.

```python
   return OBOption(label=f"{arg.nummer} - {arg.jaar} - {arg.naam}", value=arg.url)
```

Closes #319